### PR TITLE
Exclude TBB based sort algorithm on hthor cluster.

### DIFF
--- a/PerformanceTesting/ecl/02ba_sortlocal.ecl
+++ b/PerformanceTesting/ecl/02ba_sortlocal.ecl
@@ -5,7 +5,7 @@
 //version algo='mergesort'
 //version algo='parmergesort'
 //version algo='heapsort'
-//version algo='tbbstableqsort'
+//version algo='tbbstableqsort',nohthor
 
 import ^ as root;
 algo := #IFDEFINED(root.algo, 'quicksort');

--- a/PerformanceTesting/ecl/02bi_sortlocalorder.ecl
+++ b/PerformanceTesting/ecl/02bi_sortlocalorder.ecl
@@ -2,7 +2,7 @@
 //class=sort
 //version algo='parquicksort'
 //version algo='parmergesort'
-//version algo='tbbstableqsort'
+//version algo='tbbstableqsort',nohthor
 
 import ^ as root;
 algo := #IFDEFINED(root.algo, 'quicksort');

--- a/PerformanceTesting/ecl/02bj_sortlocalreverse.ecl
+++ b/PerformanceTesting/ecl/02bj_sortlocalreverse.ecl
@@ -2,7 +2,7 @@
 //class=sort
 //version algo='parquicksort'
 //version algo='parmergesort'
-//version algo='tbbstableqsort'
+//version algo='tbbstableqsort',nohthor
 
 import ^ as root;
 algo := #IFDEFINED(root.algo, 'quicksort');


### PR DESCRIPTION
Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

To avoid TBB sort related test cases fail with 'Result doesn't match to key file' error on Hthor they should exclude.

They are excluded in Regression Suite as well, based on the TBB based sort algorithm doesn't implement on Hthor cluster.
