### PR TITLE
HPCC-15598 Suppress buildindex,width(1) warning

### DIFF
--- a/PerformanceTesting/ecl/01fc_buildindexorder1.ecl
+++ b/PerformanceTesting/ecl/01fc_buildindexorder1.ecl
@@ -1,6 +1,8 @@
 //class=index
 //class=indexwrite
 
+#onwarning (10120, ignore);
+
 import $ as suite;
 import suite.perform.config;
 import suite.perform.format;


### PR DESCRIPTION
The performance suite is specifically testing the building of a
large 1-way index. This normally generates a warning to warn the
user that they may not have intended to build such a large single
part index on Thor.
In the performace suite this warning only serves to cause the
result to mismatch the result from other engines and the key
expected.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>