### PR TITLE
HPCC-15843 Suppress warnings from performance suite setup phase

### DIFF
--- a/PerformanceTesting/ecl/key/buildindexorder1.xml
+++ b/PerformanceTesting/ecl/key/buildindexorder1.xml
@@ -1,3 +1,2 @@
-<Warning><Code>10120</Code><Source>SLAVE #1</Source><Message>Graph graph1[1], indexwrite[5]: SLAVE #1 [192.168.0.200:20100]: BUILDINDEX: building single part key because marked as &apos;FEW&apos; but row count in excess of 10M</Message></Warning>
 <Dataset name='Result 1'>
 </Dataset>

--- a/PerformanceTesting/ecl/setup/buildindexorder1.ecl
+++ b/PerformanceTesting/ecl/setup/buildindexorder1.ecl
@@ -1,6 +1,8 @@
 //class=index
 //class=indexwrite
 
+#onwarning(10120, ignore);
+
 import $.^ as suite;
 import suite.perform.config;
 import suite.perform.format;


### PR DESCRIPTION
Add #onwarning() to buildindexorder1.ecl setup code

Remove 'Warning' from the buildindexorder1.xml setup keyfile

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>