### PR TITLE
File Management bundle

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,3 +75,5 @@ Other bundles
 +---------------------+------------------------------------------------+-----------------------------------------------------+
 | PrefixTree          | Improves Levenshtein edit distance performance | https://github.com/Charles-Kaminski/PrefixTree      |
 +---------------------+------------------------------------------------+-----------------------------------------------------+
+| File Management     | Manages the promotion of a set of files        | https://github.com/johnholt/File_Management         |
++---------------------+------------------------------------------------+-----------------------------------------------------+


### PR DESCRIPTION
A bundle to manage a group of files so that they are all promoted together or none of the files are promotes.  

Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>
